### PR TITLE
Sanity check the launch system

### DIFF
--- a/launch/base_hardware.launch
+++ b/launch/base_hardware.launch
@@ -1,0 +1,24 @@
+<launch>
+    <arg name="sim" default="false" doc="true if we are running in the sim" />
+    <arg name="bond_id_namespace" default="safety_bonds" />
+
+    <!-- if we're in the sim -->
+    <group if="$(arg sim)">
+        <include file="$(find iarc7_simulator)/launch/morse.launch" />
+    </group>
+    <!-- else -->
+    <group unless="$(arg sim)">
+        <include file="$(find iarc7_fc_comms)/launch/fc_comms_msp.launch">
+            <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
+            <arg name="safety_priority" value="50" />
+        </include>
+
+        <include file="$(find iarc7_sensors)/launch/altimeter.launch" />
+        <include file="$(find iarc7_launch)/launch/static_transforms.launch" />
+    </group>
+    <!-- endif -->
+
+    <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">
+        <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
+    </include>
+</launch>

--- a/launch/base_hardware.launch
+++ b/launch/base_hardware.launch
@@ -17,6 +17,7 @@
     </group>
     <!-- endif -->
 
+    <rosparam command="delete" param="$(arg bond_id_namespace)" />
     <rosparam command="load"
         file="$(find iarc7_launch)/params/safety_config.yaml" />
     <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">

--- a/launch/base_hardware.launch
+++ b/launch/base_hardware.launch
@@ -10,7 +10,6 @@
     <group unless="$(arg sim)">
         <include file="$(find iarc7_fc_comms)/launch/fc_comms_msp.launch">
             <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
-            <arg name="safety_priority" value="50" />
         </include>
 
         <include file="$(find iarc7_sensors)/launch/altimeter.launch" />
@@ -18,6 +17,8 @@
     </group>
     <!-- endif -->
 
+    <rosparam command="load"
+        file="$(find iarc7_launch)/params/safety_config.yaml" />
     <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">
         <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
     </include>

--- a/launch/main.launch
+++ b/launch/main.launch
@@ -1,17 +1,20 @@
 <launch>
     <arg name="sim" default="false" doc="true if we are running in the sim" />
+    <arg name="external_bond_ids" default=""/>
 
     <arg name="bondIds" doc="list of names of nodes to require bonds with"
         default="[
             'fc_comms_msp',
             'low_level_motion',
-            'motion_planner'
+            'motion_planner',
+            $(arg external_bond_ids)
             ]"
         unless="$(arg sim)" />
     <arg name="bondIds" doc="list of names of nodes to require bonds with"
         default="[
             'low_level_motion',
-            'motion_planner'
+            'motion_planner',
+            $(arg external_bond_ids)
             ]"
         if="$(arg sim)" />
 

--- a/launch/main.launch
+++ b/launch/main.launch
@@ -1,46 +1,16 @@
 <launch>
+    <arg name="bond_id_namespace" default="safety_bonds" />
     <arg name="sim" default="false" doc="true if we are running in the sim" />
-    <arg name="external_bond_ids" default=""/>
 
-    <arg name="bondIds" doc="list of names of nodes to require bonds with"
-        default="[
-            'fc_comms_msp',
-            'low_level_motion',
-            'motion_planner',
-            $(arg external_bond_ids)
-            ]"
-        unless="$(arg sim)" />
-    <arg name="bondIds" doc="list of names of nodes to require bonds with"
-        default="[
-            'low_level_motion',
-            'motion_planner',
-            $(arg external_bond_ids)
-            ]"
-        if="$(arg sim)" />
+    <include file="$(find iarc7_launch)/launch/base_hardware.launch">
+        <arg name="sim" value="$(arg sim)" />
+        <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
+    </include>
 
-    <!-- if we're in the sim -->
-    <group if="$(arg sim)">
-        <include file="$(find iarc7_simulator)/launch/morse.launch" />
-    </group>
-    <!-- else -->
-    <group unless="$(arg sim)">
-        <include file="$(find iarc7_fc_comms)/launch/fc_comms_msp.launch" />
-        <include file="$(find iarc7_sensors)/launch/altimeter.launch" />
-        <include file="$(find iarc7_launch)/launch/static_transforms.launch" />
-    </group>
-    <!-- endif -->
+    <include file="$(find iarc7_launch)/launch/motion_stack.launch">
+        <arg name="sim" value="$(arg sim)" />
+        <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
+    </include>
 
     <include file="$(find iarc7_launch)/launch/localization.launch" />
-
-    <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">
-        <arg name="bondIds" value="$(arg bondIds)" />
-    </include>
-
-    <include file="$(find iarc7_motion)/launch/motion_planner.launch"/>
-
-    <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
-        <arg name="platform" value="0.05" unless="$(arg sim)" />
-        <arg name="platform" value="sim" if="$(arg sim)" />
-    </include>
-
 </launch>

--- a/launch/motion_planner_test.launch
+++ b/launch/motion_planner_test.launch
@@ -1,16 +1,13 @@
-<!-- Requres ground truth localization turned on in the simulator -->
 <launch>
-    <include file="$(find iarc7_simulator)/launch/morse.launch" />
-
-    <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">
-        <arg name="bondIds" default="['low_level_motion', 'motion_planner']"/>
+    <include file="$(find iarc7_launch)/launch/base_hardware.launch">
+        <arg name="sim" value="true" />
     </include>
 
-    <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
-        <arg name="platform" value="sim" />
+    <include file="$(find iarc7_launch)/launch/motion_stack.launch">
+        <arg name="sim" value="true" />
     </include>
 
-    <include file="$(find iarc7_motion)/launch/motion_planner.launch"/>
+    <param name="sim/ground_truth_localization" value="true" />
 
     <node name="test_motion_planner" pkg="iarc7_motion" type="test_motion_planner.py" />
 </launch>

--- a/launch/motion_planner_test.launch
+++ b/launch/motion_planner_test.launch
@@ -7,6 +7,7 @@
         <arg name="sim" value="true" />
     </include>
 
+    <!-- This parameter must be true, overrides whatever's in morse.yaml -->
     <param name="sim/ground_truth_localization" value="true" />
 
     <node name="test_motion_planner" pkg="iarc7_motion" type="test_motion_planner.py" />

--- a/launch/motion_stack.launch
+++ b/launch/motion_stack.launch
@@ -1,0 +1,15 @@
+<launch>
+    <arg name="sim" default="false" doc="true if we are running in the sim" />
+    <arg name="bond_id_namespace" default="safety_bonds" />
+
+    <include file="$(find iarc7_motion)/launch/motion_planner.launch">
+        <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
+        <arg name="safety_priority" value="250" />
+    </include>
+
+    <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
+        <arg name="platform" value="0.05" unless="$(arg sim)" />
+        <arg name="platform" value="sim" if="$(arg sim)" />
+        <arg name="safety_priority" value="200" />
+    </include>
+</launch>

--- a/launch/motion_stack.launch
+++ b/launch/motion_stack.launch
@@ -4,12 +4,10 @@
 
     <include file="$(find iarc7_motion)/launch/motion_planner.launch">
         <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
-        <arg name="safety_priority" value="250" />
     </include>
 
     <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
         <arg name="platform" value="0.05" unless="$(arg sim)" />
         <arg name="platform" value="sim" if="$(arg sim)" />
-        <arg name="safety_priority" value="200" />
     </include>
 </launch>

--- a/launch/motion_stack.launch
+++ b/launch/motion_stack.launch
@@ -9,5 +9,6 @@
     <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
         <arg name="platform" value="0.05" unless="$(arg sim)" />
         <arg name="platform" value="sim" if="$(arg sim)" />
+        <arg name="bond_id_namespace" value="$(arg bond_id_namespace)" />
     </include>
 </launch>

--- a/launch/motor_test_V0.05.launch
+++ b/launch/motor_test_V0.05.launch
@@ -4,5 +4,5 @@
     </include>
 
     <node name="motors_test" pkg="iarc7_fc_comms" type="motors_test.py" output="screen"/>
-    <param name="safety_bonds/motors_test" value="1000" />
+    <param name="safety_bonds/motors_test/form_bond" value="true" />
 </launch>

--- a/launch/motor_test_V0.05.launch
+++ b/launch/motor_test_V0.05.launch
@@ -1,9 +1,8 @@
 <launch>
-    <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">
-        <arg name="bondIds" default="['fc_comms_msp', 'motors_test']"/>
+    <include file="$(find iarc7_launch)/launch/base_hardware.launch">
+        <arg name="sim" value="false" />
     </include>
 
-    <include file="$(find iarc7_fc_comms)/launch/fc_comms_msp.launch" />
-
     <node name="motors_test" pkg="iarc7_fc_comms" type="motors_test.py" output="screen"/>
+    <param name="safety_bonds/motors_test" value="1000" />
 </launch>

--- a/launch/takeoff_land.launch
+++ b/launch/takeoff_land.launch
@@ -2,7 +2,7 @@
     <arg name="sim" default="false" doc="true if we are running in the sim" />
 
     <node name="takeoff_land_abstract" pkg="iarc7_abstract" type="takeoff_land.py" />
-    <param name="safety_bonds/takeoff_land_abstract" value="1000" />
+    <param name="safety_bonds/takeoff_land_abstract/form_bond" value="true" />
 
     <include file="$(find iarc7_launch)/launch/main.launch">
         <arg name="sim" value="$(arg sim)" />

--- a/launch/takeoff_land.launch
+++ b/launch/takeoff_land.launch
@@ -2,9 +2,9 @@
     <arg name="sim" default="false" doc="true if we are running in the sim" />
 
     <node name="takeoff_land_abstract" pkg="iarc7_abstract" type="takeoff_land.py" />
+    <param name="safety_bonds/takeoff_land_abstract" value="1000" />
 
     <include file="$(find iarc7_launch)/launch/main.launch">
         <arg name="sim" value="$(arg sim)" />
-        <arg name="external_bond_ids" default="'takeoff_land_abstract'" />
     </include>
 </launch>

--- a/launch/takeoff_land.launch
+++ b/launch/takeoff_land.launch
@@ -1,47 +1,10 @@
 <launch>
     <arg name="sim" default="false" doc="true if we are running in the sim" />
 
-    <arg name="bondIds" doc="list of names of nodes to require bonds with"
-        default="[
-            'fc_comms_msp',
-            'low_level_motion',
-            'motion_planner',
-            'takeoff_land_abstract'
-            ]"
-        unless="$(arg sim)" />
-    <arg name="bondIds" doc="list of names of nodes to require bonds with"
-        default="[
-            'low_level_motion',
-            'motion_planner',
-            'takeoff_land_abstract'
-            ]"
-        if="$(arg sim)" />
-
-    <!-- if we're in the sim -->
-    <group if="$(arg sim)">
-        <include file="$(find iarc7_simulator)/launch/morse.launch" />
-    </group>
-    <!-- else -->
-    <group unless="$(arg sim)">
-        <include file="$(find iarc7_fc_comms)/launch/fc_comms_msp.launch" />
-        <include file="$(find iarc7_sensors)/launch/altimeter.launch" />
-        <include file="$(find iarc7_launch)/launch/static_transforms.launch" />
-    </group>
-    <!-- endif -->
-
-    <include file="$(find iarc7_launch)/launch/localization.launch" />
-
-    <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">
-        <arg name="bondIds" value="$(arg bondIds)" />
-    </include>
-
-    <include file="$(find iarc7_motion)/launch/motion_planner.launch"/>
-
-    <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
-        <arg name="platform" value="0.05" unless="$(arg sim)" />
-        <arg name="platform" value="sim" if="$(arg sim)" />
-    </include>
-
     <node name="takeoff_land_abstract" pkg="iarc7_abstract" type="takeoff_land.py" />
 
+    <include file="$(find iarc7_launch)/launch/main.launch">
+        <arg name="sim" value="$(arg sim)" />
+        <arg name="external_bond_ids" default="'takeoff_land_abstract'" />
+    </include>
 </launch>

--- a/launch/waypoints_test.launch
+++ b/launch/waypoints_test.launch
@@ -1,14 +1,15 @@
-<!-- Requres ground truth localization turned on in the simulator -->
 <launch>
-    <include file="$(find iarc7_simulator)/launch/morse.launch" />
-
-    <include file="$(find iarc7_safety)/launch/iarc7_safety.launch">
-        <arg name="bondIds" default="['low_level_motion', 'motion_planner']"/>
+    <include file="$(find iarc7_launch)/launch/base_hardware.launch">
+        <arg name="sim" value="true" />
     </include>
 
     <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
         <arg name="platform" value="sim" />
+        <arg name="safety_priority" value="200" />
     </include>
 
+    <param name="sim/ground_truth_localization" value="true" />
+
     <node name="waypoints_test" pkg="iarc7_motion" type="waypoints_test.py" />
+    <param name="safety_bonds/motion_planner" value="250" />
 </launch>

--- a/launch/waypoints_test.launch
+++ b/launch/waypoints_test.launch
@@ -8,6 +8,7 @@
         <arg name="safety_priority" value="200" />
     </include>
 
+    <!-- This parameter must be true, overrides whatever's in morse.yaml -->
     <param name="sim/ground_truth_localization" value="true" />
 
     <node name="waypoints_test" pkg="iarc7_motion" type="waypoints_test.py" />

--- a/launch/waypoints_test.launch
+++ b/launch/waypoints_test.launch
@@ -5,12 +5,11 @@
 
     <include file="$(find iarc7_motion)/launch/low_level_motion.launch">
         <arg name="platform" value="sim" />
-        <arg name="safety_priority" value="200" />
     </include>
 
     <!-- This parameter must be true, overrides whatever's in morse.yaml -->
     <param name="sim/ground_truth_localization" value="true" />
 
     <node name="waypoints_test" pkg="iarc7_motion" type="waypoints_test.py" />
-    <param name="safety_bonds/motion_planner" value="250" />
+    <param name="safety_bonds/motion_planner/form_bond" value="true" />
 </launch>

--- a/params/safety_config.yaml
+++ b/params/safety_config.yaml
@@ -1,11 +1,16 @@
 safety_bonds:
     fc_comms_msp:
+        form_bond: false
         priority: 50
     low_level_motion:
+        form_bond: false
         priority: 200
     motion_planner:
+        form_bond: false
         priority: 250
     takeoff_land_abstract:
+        form_bond: false
         priority: 1000
     motors_test:
+        form_bond: false
         priority: 1000

--- a/params/safety_config.yaml
+++ b/params/safety_config.yaml
@@ -1,0 +1,11 @@
+safety_bonds:
+    fc_comms_msp:
+        priority: 50
+    low_level_motion:
+        priority: 200
+    motion_planner:
+        priority: 250
+    takeoff_land_abstract:
+        priority: 1000
+    motors_test:
+        priority: 1000


### PR DESCRIPTION
Add ability to add bondId's to main.launch, abstract launch files don't have to copy all of main.launch.

This cleans up a lot of duplicate launch commands.

If there's something we can do to make this even cleaner that would be good. 